### PR TITLE
Perform an upgrade-master prior to starting buildbot

### DIFF
--- a/roles/buildbot_master/templates/buildbotctl.j2
+++ b/roles/buildbot_master/templates/buildbotctl.j2
@@ -52,6 +52,8 @@ start() {
     if [ ! -z "$pid" ]; then
         echo "buildbot master is already running (pid $pid)"
     else
+        echo "Upgrading buildbot database"
+        $BUILDBOT upgrade-master $BASEDIR
         echo "Starting buildbot ..."
         BUILDBOT_PIDFILE=$PIDFILE $BUILDBOT start --start_timeout=60 $BASEDIR
     fi


### PR DESCRIPTION
After some buildbot upgrades upgrades, the database may need to be upgraded.  Before
starting the buildbot process itself, perform a upgrade-master.

The same method is used in a docker startup script that is provided with
buildbot. (see buildbot: master/docker/start_buildbot.sh)